### PR TITLE
Updating pyyaml requirement due to vuln in older versions

### DIFF
--- a/experiments/requirements.txt
+++ b/experiments/requirements.txt
@@ -20,7 +20,7 @@ pyhsmm==0.1.6
 pyparsing==2.2.0
 python-dateutil==2.6.1
 pytz==2017.3
-pyyaml==3.12
+pyyaml>=4.2b1
 seaborn==0.8.1
 sklearn==0.0
 scipy==1.0.0


### PR DESCRIPTION
Updating pyyaml requirement to avoid arbitrary code execution vuln in pyyaml (see https://nvd.nist.gov/vuln/detail/CVE-2017-18342).